### PR TITLE
Prepare For scala.js 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,63 +1,59 @@
-scalaJSSettings
+lazy val root = (project in file(".")).
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "scalajs-angular",
+    description := "AngularJS bindings for Scala.js.",
+    organization := "com.greencatsoft",
+    version := "0.3-SNAPSHOT",
+    scalaVersion := "2.11.4",
+    scalacOptions ++= Seq("-feature","-deprecation"),
+    homepage := Some(url("http://github.com/greencatsoft/scalajs-angular")),
 
-name := "scalajs-angular"
+    libraryDependencies ++= Seq(
+      "org.scala-js" %%% "scalajs-dom" % "0.7.0",
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % "compile"
+    ),
 
-description := "AngularJS bindings for Scala.js."
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if(isSnapshot.value)
+      	Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+      	Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
 
-organization := "com.greencatsoft"
+    publishMavenStyle := true,
 
-version := "0.3-SNAPSHOT"
+    pomIncludeRepository := { _ => false },
 
-scalaVersion := "2.11.2"
-
-scalacOptions ++= Seq("-feature","-deprecation")
-
-homepage := Some(url("http://github.com/greencatsoft/scalajs-angular"))
-
-libraryDependencies ++= Seq(
-  "org.scala-lang.modules.scalajs" %%% "scalajs-dom" % "0.6",
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value % "compile"
-)
-
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if(isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
-
-publishMavenStyle := true
-
-pomIncludeRepository := { _ => false }
-
-pomExtra := (
-  <licenses>
-    <license>
-      <name>Apache License 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:greencatsoft/scalajs-angular.git</url>
-    <connection>scm:git:git@github.com:greencatsoft/scalajs-angular.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>mysticfall</id>
-      <name>Xavier Cho</name>
-      <url>http://github.com/mysticfall</url>
-    </developer>
-    <developer>
-      <id>jokade</id>
-      <name>Jokade</name>
-      <url>https://github.com/jokade</url>
-    </developer>
-    <developer>
-      <id>mmx900</id>
-      <name>Setzer Kim</name>
-      <url>https://github.com/mmx900</url>
-    </developer>
-  </developers>
-)
+    pomExtra := (
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>git@github.com:greencatsoft/scalajs-angular.git</url>
+        <connection>scm:git:git@github.com:greencatsoft/scalajs-angular.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>mysticfall</id>
+          <name>Xavier Cho</name>
+          <url>http://github.com/mysticfall</url>
+        </developer>
+        <developer>
+          <id>jokade</id>
+          <name>Jokade</name>
+          <url>https://github.com/jokade</url>
+        </developer>
+        <developer>
+          <id>mmx900</id>
+          <name>Setzer Kim</name>
+          <url>https://github.com/mmx900</url>
+        </developer>
+      </developers>
+    )
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.5.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M3" )
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 

--- a/src/main/scala/com/greencatsoft/angularjs/AngularElement.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/AngularElement.scala
@@ -7,7 +7,7 @@ import org.scalajs.dom.{ Element, Event }
 
 trait AngularElement extends Element {
 
-  def bind[T <: Event](event: String, handler: js.Function1[T, _]): Unit = ???
+  def bind[T <: Event](event: String, handler: js.Function1[T, _]): Unit = js.native
 
-  def unbind[T <: Event](event: String, handler: js.Function1[T, _]): Unit = ???
+  def unbind[T <: Event](event: String, handler: js.Function1[T, _]): Unit = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/Directive.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Directive.scala
@@ -53,25 +53,25 @@ trait Directive extends NamedService with Function0[Configuration] with Scoped w
 
 trait Attributes extends js.Object {
 
-  val $attr: js.Dictionary[String] = ???
+  val $attr: js.Dictionary[String] = js.native
 
-  def $addClass(classVal: String): Unit = ???
+  def $addClass(classVal: String): Unit = js.native
 
-  def $removeClass(classVal: String): Unit = ???
+  def $removeClass(classVal: String): Unit = js.native
 
-  def $updateClass(newClasses: String, oldClasses: String): Unit = ???
-
-  @JSBracketAccess
-  def apply(name: String): UndefOr[String] = ???
+  def $updateClass(newClasses: String, oldClasses: String): Unit = js.native
 
   @JSBracketAccess
-  def update(name: String, value: String): Unit = ???
+  def apply(name: String): UndefOr[String] = js.native
 
-  def $get(name: String): UndefOr[String] = ???
+  @JSBracketAccess
+  def update(name: String, value: String): Unit = js.native
 
-  def $set(name: String, value: String): Unit = ???
+  def $get(name: String): UndefOr[String] = js.native
 
-  def $observe(key: String, fn: js.Function1[String, Unit]): Unit = ???
+  def $set(name: String, value: String): Unit = js.native
+
+  def $observe(key: String, fn: js.Function1[String, Unit]): Unit = js.native
 }
 
 trait Requires extends ConfigBuilder {

--- a/src/main/scala/com/greencatsoft/angularjs/core/AnchorScroll.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/AnchorScroll.scala
@@ -7,5 +7,5 @@ import scala.scalajs.js
 @injectable("$anchorScroll")
 trait AnchorScroll extends js.Object {
 
-  def apply(): Unit = ???
+  def apply(): Unit = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Animate.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Animate.scala
@@ -7,15 +7,15 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$animate")
 trait Animate extends js.Object {
 
-  def enter(element: js.Object, parent: js.Object, after: js.Object, done: js.Function = null): Unit = ???
+  def enter(element: js.Object, parent: js.Object, after: js.Object, done: js.Function = null): Unit = js.native
 
-  def leave(element: js.Object, done: js.Function = null): Unit = ???
+  def leave(element: js.Object, done: js.Function = null): Unit = js.native
 
-  def move(element: js.Object, parent: js.Object, after: js.Object, done: js.Function = null): Unit = ???
+  def move(element: js.Object, parent: js.Object, after: js.Object, done: js.Function = null): Unit = js.native
 
-  def addClass(element: js.Object, className: String, done: js.Function = null): Unit = ???
+  def addClass(element: js.Object, className: String, done: js.Function = null): Unit = js.native
 
-  def removeClass(element: js.Object, className: String, done: js.Function = null): Unit = ???
+  def removeClass(element: js.Object, className: String, done: js.Function = null): Unit = js.native
 
-  def setClass(element: js.Object, add: String, remove: String, done: js.Function = null): Unit = ???
+  def setClass(element: js.Object, add: String, remove: String, done: js.Function = null): Unit = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Cache.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Cache.scala
@@ -8,21 +8,21 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$cache")
 trait Cache extends js.Object {
 
-  def info(): js.Dictionary[js.Any] = ???
+  def info(): js.Dictionary[js.Any] = js.native
 
-  def put[T <: js.Any](key: String, value: T): T = ???
+  def put[T <: js.Any](key: String, value: T): T = js.native
 
-  def get[T <: js.Any](key: String): UndefOr[T] = ???
+  def get[T <: js.Any](key: String): UndefOr[T] = js.native
 
-  def remove(key: String): Unit = ???
+  def remove(key: String): Unit = js.native
 
-  def removeAll(): Unit = ???
+  def removeAll(): Unit = js.native
 
-  def destroy(): Unit = ???
+  def destroy(): Unit = js.native
 }
 
 @injectable("$cacheFactory")
 trait CacheFactory extends js.Object {
 
-  def apply(cacheId: String, options: js.Object): Cache = ???
+  def apply(cacheId: String, options: js.Object): Cache = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Compile.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Compile.scala
@@ -13,7 +13,7 @@ trait Compile extends js.Object {
 
   type CloneAttachFunction = js.Function2[Element, Scope, Unit]
 
-  def apply(element: String, transclude: CloneAttachFunction, maxPriority: js.Number): LinkFunction = ???
+  def apply(element: String, transclude: CloneAttachFunction, maxPriority: Number): LinkFunction = js.native
 
-  def apply(element: Element, transclude: CloneAttachFunction, maxPriority: js.Number): LinkFunction = ???
+  def apply(element: Element, transclude: CloneAttachFunction, maxPriority: Number): LinkFunction = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Http.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Http.scala
@@ -13,42 +13,42 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$http")
 trait HttpService extends js.Object {
 
-  def get(url: String): HttpPromise = ???
+  def get(url: String): HttpPromise = js.native
 
-  def get(url: String, config: HttpConfig): HttpPromise = ???
+  def get(url: String, config: HttpConfig): HttpPromise = js.native
 
-  def post(url: String): HttpPromise = ???
+  def post(url: String): HttpPromise = js.native
 
-  def post(url: String, data: js.Any): HttpPromise = ???
+  def post(url: String, data: js.Any): HttpPromise = js.native
 
-  def post(url: String, data: js.Any, config: HttpConfig): HttpPromise = ???
+  def post(url: String, data: js.Any, config: HttpConfig): HttpPromise = js.native
 
-  def jsonp(url: String, config: HttpConfig): HttpPromise = ???
+  def jsonp(url: String, config: HttpConfig): HttpPromise = js.native
 
-  def put(url: String): HttpPromise = ???
+  def put(url: String): HttpPromise = js.native
 
-  def put(url: String, data: js.Any): HttpPromise = ???
+  def put(url: String, data: js.Any): HttpPromise = js.native
 
-  def put(url: String, data: js.Any, config: HttpConfig): HttpPromise = ???
+  def put(url: String, data: js.Any, config: HttpConfig): HttpPromise = js.native
 
-  def delete(url: String): HttpPromise = ???
+  def delete(url: String): HttpPromise = js.native
 
-  def delete(url: String, data: js.Any): HttpPromise = ???
+  def delete(url: String, data: js.Any): HttpPromise = js.native
 
-  def delete(url: String, data: js.Any, config: HttpConfig): HttpPromise = ???
+  def delete(url: String, data: js.Any, config: HttpConfig): HttpPromise = js.native
 }
 
 trait HttpConfig extends js.Object {
 
-  var cache = false
+  var cache : Boolean = js.native
 
-  var responseType = ""
+  var responseType : String = js.native
 
-  var headers = new js.Array[js.Any]
+  var headers : js.Array[js.Any] = js.native
 
-  var transformResponse: js.Array[js.Function2[js.Any, js.Any, js.Any]] = _
+  var transformResponse: js.Array[js.Function2[js.Any, js.Any, js.Any]] = js.native
 
-  var transformRequest: js.Array[js.Function2[js.Any, js.Any, js.Any]] = _
+  var transformRequest: js.Array[js.Function2[js.Any, js.Any, js.Any]] = js.native
 }
 
 object HttpConfig {
@@ -74,30 +74,30 @@ object HttpConfig {
 @injectable("$httpProvider")
 trait HttpProvider extends js.Object {
 
-  var defaults: HttpConfig
+  var defaults: HttpConfig = js.native
 }
 
 trait HttpPromise extends Promise {
 
-  def success(callback: js.Function1[js.Any, Unit]): this.type
+  def success(callback: js.Function1[js.Any, Unit]): this.type = js.native
 
-  def success(callback: js.Function2[js.Any, Int, Unit]): this.type
+  def success(callback: js.Function2[js.Any, Int, Unit]): this.type = js.native
 
-  def success(callback: js.Function3[js.Any, js.Any, Int, Unit]): this.type
+  def success(callback: js.Function3[js.Any, js.Any, Int, Unit]): this.type = js.native
 
-  def success(callback: js.Function4[js.Any, Int, js.Any, js.Any, Unit]): this.type
+  def success(callback: js.Function4[js.Any, Int, js.Any, js.Any, Unit]): this.type  = js.native
 
-  def success(callback: js.Function5[js.Any, Int, js.Any, js.Any, js.Any, Unit]): this.type
+  def success(callback: js.Function5[js.Any, Int, js.Any, js.Any, js.Any, Unit]): this.type = js.native
 
-  def error(callback: js.Function1[js.Any, Unit]): this.type
+  def error(callback: js.Function1[js.Any, Unit]): this.type = js.native
 
-  def error(callback: js.Function2[js.Any, Int, Unit]): this.type
+  def error(callback: js.Function2[js.Any, Int, Unit]): this.type = js.native
 
-  def error(callback: js.Function3[js.Any, js.Any, Int, Unit]): this.type
+  def error(callback: js.Function3[js.Any, js.Any, Int, Unit]): this.type = js.native
 
-  def error(callback: js.Function4[js.Any, Int, js.Any, js.Any, Unit]): this.type
+  def error(callback: js.Function4[js.Any, Int, js.Any, js.Any, Unit]): this.type = js.native
 
-  def error(callback: js.Function5[js.Any, Int, js.Any, js.Any, UndefOr[String], Unit]): this.type
+  def error(callback: js.Function5[js.Any, Int, js.Any, js.Any, UndefOr[String], Unit]): this.type = js.native
 }
 
 object HttpPromise {
@@ -106,13 +106,13 @@ object HttpPromise {
 
   trait HttpResult extends js.Object {
 
-    val config: js.Any = ???
+    val config: js.Any = js.native
 
-    val data: js.Any = ???
+    val data: js.Any = js.native
 
-    val status: Int = ???
+    val status: Int = js.native
 
-    val statusText: String = ???
+    val statusText: String = js.native
   }
 
   class HttpFuture[A](promise: Promise) extends Future[A] {

--- a/src/main/scala/com/greencatsoft/angularjs/core/Location.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Location.scala
@@ -7,24 +7,24 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$location")
 trait Location extends js.Object {
 
-  def absUrl(): String = ???
+  def absUrl(): String = js.native
 
-  def url(url: String = null, replace: String = null): String = ???
+  def url(url: String = null, replace: String = null): String = js.native
 
-  def protocol(): String = ???
+  def protocol(): String = js.native
 
-  def host(): String = ???
+  def host(): String = js.native
 
-  def port(): Int = ???
+  def port(): Int = js.native
 
-  def path(): String = ???
+  def path(): String = js.native
 
-  def path(path: String): Location = ???
+  def path(path: String): Location = js.native
 
   // TODO: refine argument types?
-  def search(search: js.Any, paramValue: js.Any = null): js.Object = ???
+  def search(search: js.Any, paramValue: js.Any = null): js.Object = js.native
 
-  def hash(hash: String = null): String = ???
+  def hash(hash: String = null): String = js.native
 
-  def replace(): Unit = ???
+  def replace(): Unit = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Parse.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Parse.scala
@@ -9,5 +9,5 @@ trait Parse extends js.Object {
 
   type ParsedExpression = js.Function2[js.Object, js.Object, js.Function]
 
-  def apply(expression: String): ParsedExpression = ???
+  def apply(expression: String): ParsedExpression = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Q.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Q.scala
@@ -14,20 +14,20 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$q")
 trait Q extends js.Object {
 
-  def defer(): Defer = ???
+  def defer(): Defer = js.native
 
-  def promise(): Promise = ???
+  def promise(): Promise = js.native
 }
 
 trait Defer extends js.Object {
 
-  def resolve(value: js.Any): Unit = ???
+  def resolve(value: js.Any): Unit = js.native
 
-  def reject(reason: String): Unit = ???
+  def reject(reason: String): Unit = js.native
 
-  def notify(value: js.Any): Unit = ???
+  def notify(value: js.Any): Unit = js.native
 
-  val promise: Promise = ???
+  val promise: Promise = js.native
 }
 
 object Defer {
@@ -58,15 +58,15 @@ object Defer {
 
 trait Promise extends js.Object {
 
-  def `then`(successCallback: js.Function1[js.Any, js.Any]): this.type = ???
+  def `then`(successCallback: js.Function1[js.Any, js.Any]): this.type = js.native
 
-  def `then`(successCallback: js.Function1[js.Any, js.Any], errorCallback: js.Function1[js.Any, Unit]): this.type = ???
+  def `then`(successCallback: js.Function1[js.Any, js.Any], errorCallback: js.Function1[js.Any, Unit]): this.type = js.native
 
-  def `then`(successCallback: js.Function1[js.Any, js.Any], errorCallback: js.Function1[js.Any, Unit], notifyCallback: js.Function1[js.Any, Unit]): this.type = ???
+  def `then`(successCallback: js.Function1[js.Any, js.Any], errorCallback: js.Function1[js.Any, Unit], notifyCallback: js.Function1[js.Any, Unit]): this.type = js.native
 
-  def `catch`(errorCallback: js.Function1[js.Any, Unit]): this.type = ???
+  def `catch`(errorCallback: js.Function1[js.Any, Unit]): this.type = js.native
 
-  def `finally`(callback: js.Function1[js.Any, Unit]): Unit = ???
+  def `finally`(callback: js.Function1[js.Any, Unit]): Unit = js.native
 }
 
 object Promise {

--- a/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
@@ -9,20 +9,20 @@ import com.greencatsoft.angularjs.{ PageController, TitledPageController, inject
 @injectable("$routeProvider")
 trait RouteProvider extends js.Object {
 
-  def when(path: String, route: Route): this.type = ???
+  def when(path: String, route: Route): this.type = js.native
 
-  def otherwise(route: Route): this.type = ???
+  def otherwise(route: Route): this.type = js.native
 }
 
 trait Route extends js.Object {
 
-  var title: UndefOr[String] = ???
+  var title: UndefOr[String] = js.native
 
-  var templateUrl: UndefOr[String] = ???
+  var templateUrl: UndefOr[String] = js.native
 
-  var controller: UndefOr[String] = ???
+  var controller: UndefOr[String] = js.native
 
-  var redirectTo: UndefOr[String] = ???
+  var redirectTo: UndefOr[String] = js.native
 }
 
 object Route {
@@ -67,13 +67,13 @@ object Route {
 
 trait RouteInfo extends js.Object {
 
-  var $$route: Route = ???
+  var $$route: Route = js.native
 
-  var loadedTemplateUrl: String = ???
+  var loadedTemplateUrl: String = js.native
 
-  var params: js.Array[js.Any] = ???
+  var params: js.Array[js.Any] = js.native
 
-  var pathParams: js.Array[js.Any] = ???
+  var pathParams: js.Array[js.Any] = js.native
 
-  var scope: Scope = ???
+  var scope: Scope = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Scope.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Scope.scala
@@ -7,29 +7,29 @@ import com.greencatsoft.angularjs.{ Initializable, Service, inject, injectable }
 @injectable("$scope")
 trait Scope extends js.Object {
 
-  def $id: String = ???
+  def $id: String = js.native
 
-  def $apply(exp: js.Any = null): js.Any = ???
+  def $apply(exp: js.Any = null): js.Any = js.native
 
-  def $broadcast(name: String, args: js.Any*): js.Object = ???
+  def $broadcast(name: String, args: js.Any*): js.Object = js.native
 
-  def $destroy(): Unit = ???
+  def $destroy(): Unit = js.native
 
-  def $digest(): Unit = ???
+  def $digest(): Unit = js.native
 
-  def $emit(name: String, args: js.Any*): js.Object = ???
+  def $emit(name: String, args: js.Any*): js.Object = js.native
 
-  def $eval(expression: js.Any = null, locals: js.Object = null): js.Any = ???
+  def $eval(expression: js.Any = null, locals: js.Object = null): js.Any = js.native
 
-  def $evalAsync(expression: js.Any = null): Unit = ???
+  def $evalAsync(expression: js.Any = null): Unit = js.native
 
-  def $new(isolate: Boolean): Scope = ???
+  def $new(isolate: Boolean): Scope = js.native
 
-  def $on(name: String, listener: js.Function): js.Any = ???
+  def $on(name: String, listener: js.Function): js.Any = js.native
 
-  def $watch(watchExpression: js.Any, listener: js.Any = null, objectEquality: Boolean = false): js.Function = ???
+  def $watch(watchExpression: js.Any, listener: js.Any = null, objectEquality: Boolean = false): js.Function = js.native
 
-  def $watchCollection(obj: js.Any, listener: js.Function): js.Function = ???
+  def $watchCollection(obj: js.Any, listener: js.Function): js.Function = js.native
 }
 
 trait Scoped {

--- a/src/main/scala/com/greencatsoft/angularjs/core/Timer.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Timer.scala
@@ -7,15 +7,15 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$interval")
 trait Interval extends js.Object {
 
-  def apply(fn: js.Function0[_], delay: Int = 0, invokeApply: Boolean = true): Promise = ???
+  def apply(fn: js.Function0[_], delay: Int = 0, invokeApply: Boolean = true): Promise = js.native
 
-  def cancel(promise: Promise = null): Boolean = ???
+  def cancel(promise: Promise = null): Boolean = js.native
 }
 
 @injectable("$timeout")
 trait Timeout extends js.Object {
 
-  def apply(fn: js.Function0[_], delay: Int = 0, invokeApply: Boolean = true): Promise = ???
+  def apply(fn: js.Function0[_], delay: Int = 0, invokeApply: Boolean = true): Promise = js.native
 
-  def cancel(promise: Promise = null): Boolean = ???
+  def cancel(promise: Promise = null): Boolean = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
@@ -15,22 +15,22 @@ import com.greencatsoft.angularjs.injectable
 @injectable("$upload")
 trait FileUpload extends js.Object {
 
-  def upload(config: FileUploadConfig): FileUploadPromise = ???
+  def upload(config: FileUploadConfig): FileUploadPromise = js.native
 }
 
 trait FileUploadConfig extends js.Object {
 
-  var url: String = _
+  var url: String = js.native
 
-  var data: Any = _
+  var data: Any = js.native
 
-  var file: File = _
+  var file: File = js.native
 
-  var method: String = _
+  var method: String = js.native
 
-  var fileName: js.Any = _
+  var fileName: js.Any = js.native
 
-  var fileFormDataName: js.Any = _
+  var fileFormDataName: js.Any = js.native
 }
 
 object FileUploadConfig {
@@ -52,14 +52,14 @@ object FileUploadConfig {
 
 trait FileUploadPromise extends HttpPromise {
 
-  def progress(listener: js.Function1[ProgressEvent, Unit]): this.type = ???
+  def progress(listener: js.Function1[ProgressEvent, Unit]): this.type = js.native
 
-  def abort(): Unit = ???
+  def abort(): Unit = js.native
 }
 
 class ProgressEvent extends js.Object {
 
-  val loaded: Double = ???
+  val loaded: Double = js.native
 
-  val total: Double = ???
+  val total: Double = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/extensions/I18next.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/I18next.scala
@@ -15,33 +15,33 @@ trait I18next extends js.Object
 
 @injectable("$i18nextProvider")
 trait I18nextProvider extends js.Object {
-  var options: I18nextOptions = ???
+  var options: I18nextOptions = js.native
 }
 
 trait I18nextOptions extends js.Object {
 
-  var lng: String = ???
+  var lng: String = js.native
 
-  var detectLngQS: String = ???
+  var detectLngQS: String = js.native
 
-  var cookieName: String = ???
+  var cookieName: String = js.native
 
-  var cookieDomain: String = ???
+  var cookieDomain: String = js.native
 
-  var useCookie: Boolean = ???
+  var useCookie: Boolean = js.native
 
-  var ns: NamespaceConfig = ???
+  var ns: NamespaceConfig = js.native
 
-  var fallbackLng: String = ???
+  var fallbackLng: String = js.native
 
-  var resGetPath: String = ???
+  var resGetPath: String = js.native
 }
 
 trait NamespaceConfig extends js.Object {
 
-  var namespaces: js.Array[String] = ???
+  var namespaces: js.Array[String] = js.native
 
-  var defaultNs: String = ???
+  var defaultNs: String = js.native
 }
 
 object NamespaceConfig {

--- a/src/main/scala/com/greencatsoft/angularjs/extensions/Modal.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/Modal.scala
@@ -13,24 +13,24 @@ import com.greencatsoft.angularjs.core.Promise
 @injectable("$modal")
 trait ModalService extends js.Object {
 
-  def open(options: ModalOptions): ModalInstance = ???
+  def open(options: ModalOptions): ModalInstance = js.native
 }
 
 trait ModalOptions extends js.Object {
 
-  var templateUrl: String = _
+  var templateUrl: String = js.native
 
-  var controller: String = _
+  var controller: String = js.native
 
-  var scope: Any = _
+  var scope: Any = js.native
 
-  var size: String = _
+  var size: String = js.native
 
-  var windowClass: String = _
+  var windowClass: String = js.native
 
-  var backdrop = true
+  var backdrop : Boolean = js.native
 
-  var keyboard = true
+  var keyboard : Boolean = js.native
 }
 
 object ModalOptions {
@@ -47,13 +47,13 @@ object ModalOptions {
 @injectable("$modalInstance")
 trait ModalInstance extends js.Object {
 
-  def close(result: js.Any): Unit = ???
+  def close(result: js.Any): Unit = js.native
 
-  def close(): Unit = ???
+  def close(): Unit = js.native
 
-  def dismiss(reason: js.Any): Unit = ???
+  def dismiss(reason: js.Any): Unit = js.native
 
-  def result: Promise = ???
+  def result: Promise = js.native
 
-  def opened: Promise = ???
+  def opened: Promise = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/extensions/UIRouter.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/UIRouter.scala
@@ -14,8 +14,8 @@ import js.JSConverters._
  */
 
 /**
- * The $stateParams service is an object that will have one key per url parameter.
- * The $stateParams is a perfect way to provide your controllers or other services with
+ * The \$stateParams service is an object that will have one key per url parameter.
+ * The \$stateParams is a perfect way to provide your controllers or other services with
  * the individual parts of the navigated url.<br/>
  * If you had a url on your state of:
  *
@@ -25,7 +25,7 @@ import js.JSConverters._
  *
  * '/users/123/details//0'
  *
- * Your $stateParams object would be
+ * Your \$stateParams object would be
  *
  * { id:'123', type:'', repeat:'0' }
  *
@@ -33,7 +33,7 @@ import js.JSConverters._
  *
  * '/users/123/details/default/0?from=there&to=here'
  *
- * Your $stateParams object would be
+ * Your \$stateParams object would be
  *
  * { id:'123', type:'default', repeat:'0', from:'there', to:'here' }
  */
@@ -41,17 +41,17 @@ import js.JSConverters._
 trait StateParams extends js.Object {
   /**
    * Get the parameter value from its name.<br/>
-   * If you have a $stateParams object { id:'123', type:'default', repeat:'0', from:'there', to:'here' },
-   * then to get the value of the "type" key, you should call $stateParams("type").
+   * If you have a \$stateParams object { id:'123', type:'default', repeat:'0', from:'there', to:'here' },
+   * then to get the value of the "type" key, you should call \$stateParams("type").
    */
   @JSBracketAccess
-  def apply(key: String): js.Any = ???
+  def apply(key: String): js.Any = js.native
   @JSBracketAccess
-  def update(key: String, v: js.Any): Unit = ???
+  def update(key: String, v: js.Any): Unit = js.native
 }
 
 /**
- * The $stateProvider works similar to Angular's v1 router, but it focuses purely on state.
+ * The \$stateProvider works similar to Angular's v1 router, but it focuses purely on state.
  *
  * A state corresponds to a "place" in the application in terms of the overall UI and navigation.
  * A state describes (via the controller / template / view properties) what the UI looks like and does at that place.
@@ -61,26 +61,26 @@ trait StateParams extends js.Object {
  */
 @injectable("$stateProvider")
 trait StateProvider extends js.Object {
-  def state(name: String, config: State): StateProvider = ???
-  def state(config: State): StateProvider = ???
-  def decorator(name: String = ???, decorator: js.Function2[State, js.Function, Any] = ???): js.Dynamic = ???
+  def state(name: String, config: State): StateProvider = js.native
+  def state(config: State): StateProvider = js.native
+  def decorator(name: String = js.native, decorator: js.Function2[State, js.Function, Any] = js.native): js.Dynamic = js.native
 }
 
 trait State extends js.Object {
-  var name: String = ???
-  var template: String = ???
-  var templateUrl: String = ???
-  var templateProvider: js.Any = ???
-  var controller: js.Any = ???
-  var controllerAs: String = ???
-  var controllerProvider: js.Any = ???
-  var url: String = ???
-  var params: js.Array[js.Any] = ???
-  var `abstract`: Boolean = ???
-  var onEnter: js.Function = ???
-  var onExit: js.Function = ???
-  var data: js.Any = ???
-  var views: js.Dictionary[View] = ???
+  var name: String = js.native
+  var template: String = js.native
+  var templateUrl: String = js.native
+  var templateProvider: js.Any = js.native
+  var controller: js.Any = js.native
+  var controllerAs: String = js.native
+  var controllerProvider: js.Any = js.native
+  var url: String = js.native
+  var params: js.Array[js.Any] = js.native
+  var `abstract`: Boolean = js.native
+  var onEnter: js.Function = js.native
+  var onExit: js.Function = js.native
+  var data: js.Any = js.native
+  var views: js.Dictionary[View] = js.native
 }
 
 object State {
@@ -95,8 +95,8 @@ object State {
 }
 
 trait View extends js.Object {
-  var templateUrl: String = ???
-  var controller: String = ???
+  var templateUrl: String = js.native
+  var controller: String = js.native
 }
 
 object View {
@@ -109,34 +109,34 @@ object View {
 }
 
 /**
- * $urlRouterProvider has the responsibility of watching $location.
- * When $location changes it runs through a list of rules one by one until a match is found.
- * $urlRouterProvider is used behind the scenes anytime you specify a url in a state configuration.
+ * \$urlRouterProvider has the responsibility of watching \$location.
+ * When \$location changes it runs through a list of rules one by one until a match is found.
+ * \$urlRouterProvider is used behind the scenes anytime you specify a url in a state configuration.
  * All urls are compiled into a UrlMatcher object.
  */
 @injectable("$urlRouterProvider")
 trait UrlRouterProvider extends js.Object {
-  def when(whenPath: RegExp, handler: js.Function): UrlRouterProvider = ???
-  def when(whenPath: RegExp, toPath: String): UrlRouterProvider = ???
-  def when(whenPath: UrlMatcher, hanlder: js.Function): UrlRouterProvider = ???
+  def when(whenPath: RegExp, handler: js.Function): UrlRouterProvider = js.native
+  def when(whenPath: RegExp, toPath: String): UrlRouterProvider = js.native
+  def when(whenPath: UrlMatcher, hanlder: js.Function): UrlRouterProvider = js.native
   /**
    * Defines a path that is used when an invalid route is requested.
    * The function rule that returns the url path. The function is passed
-   * two params: $injector and $location services, and must return a url string.
+   * two params: \$injector and \$location services, and must return a url string.
    */
-  def otherwise(handler: js.Function): UrlRouterProvider = ???
+  def otherwise(handler: js.Function): UrlRouterProvider = js.native
   /**
    * Defines a path that is used when an invalid route is requested.
-   * $path : The url path you want to redirect to
+   * \$path : The url path you want to redirect to
    */
-  def otherwise(path: String): UrlRouterProvider = ???
-  def rule(handler: js.Function): UrlRouterProvider = ???
+  def otherwise(path: String): UrlRouterProvider = js.native
+  def rule(handler: js.Function): UrlRouterProvider = js.native
 
 }
 
 trait UrlMatcher extends js.Object {
-  def concat(pattern: String): UrlMatcher = ???
-  def exec(path: String, searchParams: js.Any): js.Any = ???
-  def parameters(): js.Array[String] = ???
-  def format(values: js.Any): String = ???
+  def concat(pattern: String): UrlMatcher = js.native
+  def exec(path: String, searchParams: js.Any): js.Any = js.native
+  def parameters(): js.Array[String] = js.native
+  def format(values: js.Any): String = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -13,11 +13,11 @@ import ServiceProxy.newInstance
 
 private[angularjs] trait Angular extends js.Object {
 
-  def module(name: String): UndefOr[Module] = ???
+  def module(name: String): UndefOr[Module] = js.native
 
-  def module(name: String, require: js.Array[String]): Module = ???
+  def module(name: String, require: js.Array[String]): Module = js.native
 
-  def element(elem: Element): AngularElement = ???
+  def element(elem: Element): AngularElement = js.native
 }
 
 private[angularjs] object Angular {

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Module.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Module.scala
@@ -4,13 +4,13 @@ import scala.scalajs.js
 
 private[angularjs] trait Module extends js.Object {
 
-  def factory(name: String, constructor: js.Array[js.Any]): Module = ???
+  def factory(name: String, constructor: js.Array[js.Any]): Module = js.native
 
-  def controller(name: String, constructor: js.Array[js.Any]): Module = ???
+  def controller(name: String, constructor: js.Array[js.Any]): Module = js.native
 
-  def config(constructor: js.Array[js.Any]): Module = ???
+  def config(constructor: js.Array[js.Any]): Module = js.native
 
-  def run(constructor: js.Array[js.Any]): Module = ???
+  def run(constructor: js.Array[js.Any]): Module = js.native
 
-  def directive(name: String, directiveFactory: js.Array[js.Any]): Module = ???
+  def directive(name: String, directiveFactory: js.Array[js.Any]): Module = js.native
 }

--- a/src/main/scala/com/greencatsoft/angularjs/internal/package.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/package.scala
@@ -5,7 +5,7 @@ import scala.scalajs.js.{ GlobalScope, UndefOr }
 
 package object internal extends GlobalScope {
 
-  private[angularjs] val angular: Angular = ???
+  private[angularjs] val angular: Angular = js.native
 
   type Configuration = js.Dictionary[js.Any]
 }


### PR DESCRIPTION
* Convert member bodies to be defined with js.native instead of ??? or _
* Fix documentation warnings in UIRouter.scala
* Update to sbt 0.13.7
* Update to scala 2.11.4
* Change Organization/Module to new values for scala.js
* Use scala.js version 0.6.0-M3
* Revise build.sbt to use the scala.js sbt plugin and other minor refinements

This might be a little preliminary as 0.6.0 is not released yet, but as I'm working with 0.6.0-M3 I need these changes in order to work with scalajs-angular. However, you'll need these changes eventually and it fixes deprecated code that will be incompatible with scala.js 1.0.0. 