### PR TITLE
Method chaining on Angular.module workaround

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/Module.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Module.scala
@@ -8,29 +8,64 @@ class Module private[angularjs] (val module: internal.Module) {
 
   import internal.{ Angular => angular }
 
-  def config[A <: Config](target: A): Unit = macro angular.config[A]
+  def config[A <: Config](target: A): Module = macro angular.config[A]
 
-  def config[A <: Config]: Unit = macro angular.configFromClass[A]
+  def config[A <: Config]: Module = macro angular.configFromClass[A]
 
-  def controller[A <: Controller[_]](target: A): Unit = macro angular.controller[A]
+  def $config(constructor: js.Array[js.Any]): Module = {
+    module.config(constructor)
+    this
+  }
 
-  def controller[A <: Controller[_]]: Unit = macro angular.controllerFromClass[A]
+  def controller[A <: Controller[_]](target: A): Module = macro angular.controller[A]
 
-  def directive[A <: Directive](target: A): Unit = macro angular.directive[A]
+  def controller[A <: Controller[_]]: Module = macro angular.controllerFromClass[A]
 
-  def directive[A <: Directive]: Unit = macro angular.directiveFromClass[A]
+  def $controller(name: String, constructor: js.Array[js.Any]): Module = {
+    module.controller(name, constructor)
+    this
+  }
 
-  def factory[A <: Factory[_]](target: A): Unit = macro angular.factory[A]
+  def directive[A <: Directive](target: A): Module = macro angular.directive[A]
 
-  def factory[A <: Factory[_]]: Unit = macro angular.factoryFromClass[A]
+  def directive[A <: Directive]: Module = macro angular.directiveFromClass[A]
 
-  def run[A <: Runnable](target: A): Unit = macro angular.run[A]
+  def $directive(name: String, directiveFactory: js.Array[js.Any]): Module = {
+    module.controller(name, directiveFactory)
+    this
+  }
 
-  def run[A <: Runnable]: Unit = macro angular.runFromClass[A]
+  def factory[A <: Factory[_]](target: A): Module = macro angular.factory[A]
 
-  def service[A <: Service](target: A): Unit = macro angular.service[A]
+  def factory[A <: Factory[_]]: Module = macro angular.factoryFromClass[A]
 
-  def filter[A <: Filter[_]](target: A): Unit = macro angular.filter[A]
+  def $factory(name: String, constructor: js.Array[js.Any]): Module = {
+    module.factory(name, constructor)
+    this
+  }
 
-  def filter[A <: Filter[_]]: Unit = macro angular.filterFromClass[A]
+  def run[A <: Runnable](target: A): Module = macro angular.run[A]
+
+  def run[A <: Runnable]: Module = macro angular.runFromClass[A]
+
+  def $run(constructor: js.Array[js.Any]): Module = {
+    module.run(constructor)
+    this
+  }
+
+  def service[A <: Service](target: A): Module = macro angular.service[A]
+
+  def $service(name: String, constructor: js.Array[js.Any]): Module = {
+    module.service(name, constructor)
+    this
+  }
+
+  def filter[A <: Filter[_]](target: A): Module = macro angular.filter[A]
+
+  def filter[A <: Filter[_]]: Module = macro angular.filterFromClass[A]
+
+  def $filter(name: String, constructor: js.Array[js.Any]): Module = {
+    module.filter(name, constructor)
+    this
+  }
 }

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -22,117 +22,117 @@ private[angularjs] object Angular {
 
   import ServiceProxy.{ identifier, newClassWrapper, newObjectWrapper }
 
-  def config[A <: Config](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def config[A <: Config](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newObjectWrapper(c)(target)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.config($proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$config($proxy)}")
   }
 
-  def configFromClass[A <: Config](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def configFromClass[A <: Config](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newClassWrapper(c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.config($proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$config($proxy)}")
   }
 
-  def controller[A <: Controller[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def controller[A <: Controller[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newObjectWrapper(c)(target)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.controller($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$controller($name, $proxy)}")
   }
 
-  def controllerFromClass[A <: Controller[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
-    import c.universe._
-
-    val proxy = newClassWrapper(c)
-    val name = moduleName[A](c)
-
-    c.Expr[Unit](q"{${c.prefix.tree}.module.controller($name, $proxy)}")
-  }
-
-  def directive[A <: Directive](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
-    import c.universe._
-
-    val proxy = newObjectWrapper(c)(target)
-    val name = moduleName[A](c)
-
-    c.Expr[Unit](q"{${c.prefix.tree}.module.directive($name, $proxy)}")
-  }
-
-  def directiveFromClass[A <: Directive](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def controllerFromClass[A <: Controller[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newClassWrapper(c)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.directive($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$controller($name, $proxy)}")
   }
 
-  def factory[A <: Factory[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def directive[A <: Directive](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newObjectWrapper(c)(target)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.factory($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.module.directive($name, $proxy)}")
   }
 
-  def factoryFromClass[A <: Factory[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def directiveFromClass[A <: Directive](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newClassWrapper(c)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.factory($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$directive($name, $proxy)}")
   }
 
-  def run[A <: Runnable](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
-    import c.universe._
-
-    val proxy = newObjectWrapper(c)(target)
-
-    c.Expr[Unit](q"{${c.prefix.tree}.module.run($proxy)}")
-  }
-
-  def runFromClass[A <: Runnable](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
-    import c.universe._
-
-    val proxy = newClassWrapper(c)
-
-    c.Expr[Unit](q"{${c.prefix.tree}.module.run($proxy)}")
-  }
-
-  def service[A <: Service](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def factory[A <: Factory[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newObjectWrapper(c)(target)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.service($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$factory($name, $proxy)}")
   }
 
-  def filter[A <: Filter[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
-    import c.universe._
-
-    val proxy = newObjectWrapper(c)(target)
-    val name = moduleName[A](c)
-
-    c.Expr[Unit](q"{${c.prefix.tree}.module.filter($name, $proxy)}")
-  }
-
-  def filterFromClass[A <: Filter[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[Unit] = {
+  def factoryFromClass[A <: Factory[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
     import c.universe._
 
     val proxy = newClassWrapper(c)
     val name = moduleName[A](c)
 
-    c.Expr[Unit](q"{${c.prefix.tree}.module.filter($name, $proxy)}")
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$factory($name, $proxy)}")
+  }
+
+  def run[A <: Runnable](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
+    import c.universe._
+
+    val proxy = newObjectWrapper(c)(target)
+
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$run($proxy)}")
+  }
+
+  def runFromClass[A <: Runnable](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
+    import c.universe._
+
+    val proxy = newClassWrapper(c)
+
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$run($proxy)}")
+  }
+
+  def service[A <: Service](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
+    import c.universe._
+
+    val proxy = newObjectWrapper(c)(target)
+    val name = moduleName[A](c)
+
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$service($name, $proxy)}")
+  }
+
+  def filter[A <: Filter[_]](c: Context)(target: c.Expr[A])(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
+    import c.universe._
+
+    val proxy = newObjectWrapper(c)(target)
+    val name = moduleName[A](c)
+
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$filter($name, $proxy)}")
+  }
+
+  def filterFromClass[A <: Filter[_]](c: Context)(implicit tag: c.WeakTypeTag[A]): c.Expr[api.Module] = {
+    import c.universe._
+
+    val proxy = newClassWrapper(c)
+    val name = moduleName[A](c)
+
+    c.Expr[api.Module](q"{${c.prefix.tree}.$$filter($name, $proxy)}")
   }
 
   private def moduleName[A <: Service](c: Context)(implicit tag: c.WeakTypeTag[A]): c.universe.Literal = {


### PR DESCRIPTION
Just a workaround for method chaining on Angular.module.

I think it's too difficult to deal with macro because c.prefix.tree (in macros) returns the method call site and not the Module class instance.
And the underlying methods are pure javascript calls, so they will never return a "scala-js object".

May close #46

Please have a look
(I use it in my project, it's ok)