### PR TITLE
Big problem with the new ResourceRequestConfig

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/core/Resource.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Resource.scala
@@ -180,7 +180,7 @@ object ResourceRequestConfig {
     url: String = null,
     timeout: Int = -1): ResourceRequestConfig = {
 
-    val t = js.Dynamic.literal.asInstanceOf[ResourceRequestConfig]
+    val t = js.Object().asInstanceOf[ResourceRequestConfig]
 
     if (!isArray) t.isArray = isArray
     if (params != null) t.params = params


### PR DESCRIPTION
If you don't use ResourceRequestConfig, you don't have this problem.

I did a mistake on Resource.scala for ResourceRequestConfig :

```scala
js.Dynamic.literal.asInstanceOf[ResourceRequestConfig]
```
instead of :
```scala
js.Object().asInstanceOf[ResourceRequestConfig]
```

Consequence :
If you use ResourceRequestConfig it may modifiy the js.Dynamic.literal but if you've additional urls and methods on a Resource, all these methods will use the same ResourceRequestConfig.

Example :
```scala
class ResourceService extends EnhancedResource[CustomClass] {
  def method1(params: js.Dictionary[Any]) : ResourceResponse[Any] = js.native
  def method2(params: js.Dictionary[Any]) : ResourceResponse[Any] = js.native
  def method3(params: js.Dictionary[Any]) : ResourceResponse[Any] = js.native
}

class CustomServiceFactory(resource: ResourceService) extends Factory[CustomService] {
  override def apply(): CustomService = resource("/custom/:id", null, js.Dictionary(
      "method1" -> ResourceRequestConfig(url = "/custom/:id/method1", method="POST"),
      "method2" -> ResourceRequestConfig(url = "/custom/:id/method2", method="POST"),
      "method3" -> ResourceRequestConfig(url = "/custom/:id/method3", method="POST"))).asInstanceOf[CustomService]
}
```

All methods 1,2,3 will make request to url /custom/:id/method3 because it's the last modifications on js.Dynamic.literal. So the last one is always used.

Please merge ASAP.

Sorry and thanks in advance.