### PR TITLE
Rename root project to scalaJsAngular

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val root = (project in file(".")).
+lazy val scalaJsAngular = (project in file(".")).
   enablePlugins(ScalaJSPlugin).
   settings(
     name := "scalajs-angular",


### PR DESCRIPTION
- Prevents conflict when included as sbt submodule