### PR TITLE
Location.url() returns js.Object instead of String

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/core/Location.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Location.scala
@@ -75,7 +75,9 @@ trait Location extends js.Object {
 
   def absUrl(): String = js.native
 
-  def url(url: String = null, replace: String = null): String = js.native
+  def url(): String = js.native
+
+  def url(url: String, replace: String = null): Location = js.native
 
   def protocol(): String = js.native
 


### PR DESCRIPTION
I got some UBE's attempting to use Location.url(). Apparently the return result is an object, not a string.