### PR TITLE
Changed type of templateUrl in Route…

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
@@ -3,6 +3,7 @@ package com.greencatsoft.angularjs.core
 import scala.scalajs.js
 import scala.scalajs.js.UndefOr
 import scala.scalajs.js.annotation.JSBracketAccess
+import js.|
 
 import com.greencatsoft.angularjs.injectable
 
@@ -33,7 +34,7 @@ trait Route extends js.Object {
 
   var template: UndefOr[String] = js.native
 
-  var templateUrl: UndefOr[String] = js.native
+  var templateUrl: UndefOr[String | js.Function] = js.native
 
   var controller: UndefOr[String] = js.native
 
@@ -44,17 +45,17 @@ trait Route extends js.Object {
 
 object Route {
 
-  def apply(templateUrl: String): Route =
+  def apply(templateUrl: String | js.Function): Route =
     apply(templateUrl, None, None, None)
 
-  def apply(templateUrl: String, title: String): Route =
+  def apply(templateUrl: String | js.Function, title: String): Route =
     apply(templateUrl, Some(title), None, None)
 
-  def apply(templateUrl: String, title: String, controller: String): Route =
+  def apply(templateUrl: String | js.Function, title: String, controller: String): Route =
     apply(templateUrl, Some(title), Some(controller), None)
 
   def apply(
-    templateUrl: String, title: Option[String], controller: Option[String], redirectTo: Option[String]): Route = {
+    templateUrl: String | js.Function, title: Option[String], controller: Option[String], redirectTo: Option[String]): Route = {
     require(templateUrl != null, "Missing argument 'templateUrl'.")
     require(title != null, "Missing argument 'title'.")
     require(controller != null, "Missing argument 'controller'.")
@@ -100,7 +101,7 @@ class RouteBuilder {
     this
   }
 
-  def templateUrl(templateUrl: String): RouteBuilder = {
+  def templateUrl(templateUrl: String | js.Function): RouteBuilder = {
     route.templateUrl = templateUrl
     this
   }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
@@ -34,7 +34,7 @@ trait Route extends js.Object {
 
   var template: UndefOr[String] = js.native
 
-  var templateUrl: UndefOr[String | js.Function] = js.native
+  var templateUrl: UndefOr[String | js.Function1[RouteParams, String]] = js.native
 
   var controller: UndefOr[String] = js.native
 
@@ -45,17 +45,17 @@ trait Route extends js.Object {
 
 object Route {
 
-  def apply(templateUrl: String | js.Function): Route =
+  def apply(templateUrl: String | js.Function1[RouteParams, String]): Route =
     apply(templateUrl, None, None, None)
 
-  def apply(templateUrl: String | js.Function, title: String): Route =
+  def apply(templateUrl: String | js.Function1[RouteParams, String], title: String): Route =
     apply(templateUrl, Some(title), None, None)
 
-  def apply(templateUrl: String | js.Function, title: String, controller: String): Route =
+  def apply(templateUrl: String | js.Function1[RouteParams, String], title: String, controller: String): Route =
     apply(templateUrl, Some(title), Some(controller), None)
 
   def apply(
-    templateUrl: String | js.Function, title: Option[String], controller: Option[String], redirectTo: Option[String]): Route = {
+    templateUrl: String | js.Function1[RouteParams, String], title: Option[String], controller: Option[String], redirectTo: Option[String]): Route = {
     require(templateUrl != null, "Missing argument 'templateUrl'.")
     require(title != null, "Missing argument 'title'.")
     require(controller != null, "Missing argument 'controller'.")
@@ -101,7 +101,7 @@ class RouteBuilder {
     this
   }
 
-  def templateUrl(templateUrl: String | js.Function): RouteBuilder = {
+  def templateUrl(templateUrl: String | js.Function1[RouteParams, String]): RouteBuilder = {
     route.templateUrl = templateUrl
     this
   }

--- a/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Route.scala
@@ -32,7 +32,7 @@ trait Route extends js.Object {
 
   var title: UndefOr[String] = js.native
 
-  var template: UndefOr[String] = js.native
+  var template: UndefOr[String | js.Function1[RouteParams, String]] = js.native
 
   var templateUrl: UndefOr[String | js.Function1[RouteParams, String]] = js.native
 
@@ -96,7 +96,7 @@ class RouteBuilder {
     this
   }
 
-  def template(template: String): RouteBuilder = {
+  def template(template: String | js.Function1[RouteParams, String]): RouteBuilder = {
     route.template = template
     this
   }


### PR DESCRIPTION
from ``String`` union type ``String | js.Function``. 
The union type was introduced with [Scala.js 0.6.5](http://www.scala-js.org/news/2015/08/31/announcing-scalajs-0.6.5/).
This allows alternatively the definition of functions which constructs a template URL, like this:

```scala
class RoutingConfig(routeProvider: RouteProvider) extends Config {
   
   // function value to dynamically construct a templateUrl 
   private val viewByParam: js.Function = (params: RouteParams) => {
      val myParam = params.get("myparam")
      s"/assets/views/$myParam.tpl.html"
   }

   routeProvider
      // with static string
     .when("/home", Route("/assets/home.tpl.html", "Home", "homeController"))
      // with function defined above
     .when("/views/:myparam", Route(viewByParam, "View", "viewController"))
}
```
