### PR TITLE
Make ScopeOps available for non-Service classes

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/core/Scope.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/core/Scope.scala
@@ -38,7 +38,6 @@ trait Scope extends js.Object {
 trait RootScope extends Scope
 
 trait ScopeOps {
-  this: Service =>
 
   implicit class DynamicScope(scope: Scope) {
 


### PR DESCRIPTION
The dynamic scope is especially useful for writing unit tests, so that it is helpful to add the `ScopeOps` trait to the test suite.