### PR TITLE
Make Angular.injector() work

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Angular.scala
@@ -16,7 +16,7 @@ object Angular {
   def apply(name: String): Option[Module] =
     angular.module(name).toOption.map(new Module(_))
 
-  def injector: Injector = angular.injector
+  def injector: Injector = angular.injector()
 
   def injector(modules: String*): Injector = angular.injector(modules.toJSArray)
 

--- a/src/main/scala/com/greencatsoft/angularjs/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Angular.scala
@@ -16,7 +16,7 @@ object Angular {
   def apply(name: String): Option[Module] =
     angular.module(name).toOption.map(new Module(_))
 
-  def injector: Injector = angular.injector
+  def injector(modules: String*): Injector = angular.injector(modules.toJSArray)
 
   def module(name: String, dependencies: Seq[String] = Nil): Module =
     new Module(angular.module(name, dependencies.toJSArray))

--- a/src/main/scala/com/greencatsoft/angularjs/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Angular.scala
@@ -16,7 +16,7 @@ object Angular {
   def apply(name: String): Option[Module] =
     angular.module(name).toOption.map(new Module(_))
 
-  def injector(): Injector = angular.injector()
+  def injector: Injector = angular.injector
 
   def injector(modules: String*): Injector = angular.injector(modules.toJSArray)
 

--- a/src/main/scala/com/greencatsoft/angularjs/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Angular.scala
@@ -16,6 +16,8 @@ object Angular {
   def apply(name: String): Option[Module] =
     angular.module(name).toOption.map(new Module(_))
 
+  def injector(): Injector = angular.injector()
+
   def injector(modules: String*): Injector = angular.injector(modules.toJSArray)
 
   def module(name: String, dependencies: Seq[String] = Nil): Module =

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -15,7 +15,7 @@ import scala.scalajs.js.{ UndefOr, | }
 @js.native
 private[angularjs] trait Angular extends js.Object {
 
-  def injector: Injector = js.native
+  def injector(): Injector = js.native
 
   def injector(modules: js.Array[String]): Injector = js.native
 

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -15,6 +15,8 @@ import scala.scalajs.js.{ UndefOr, | }
 @js.native
 private[angularjs] trait Angular extends js.Object {
 
+  def injector(): Injector = js.native
+
   def injector(modules: js.Array[String]): Injector = js.native
 
   def module(name: String): UndefOr[Module] = js.native

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -15,7 +15,7 @@ import scala.scalajs.js.{ UndefOr, | }
 @js.native
 private[angularjs] trait Angular extends js.Object {
 
-  def injector(): Injector = js.native
+  def injector(modules: js.Array[String]): Injector = js.native
 
   def module(name: String): UndefOr[Module] = js.native
 

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Angular.scala
@@ -15,7 +15,7 @@ import scala.scalajs.js.{ UndefOr, | }
 @js.native
 private[angularjs] trait Angular extends js.Object {
 
-  def injector(): Injector = js.native
+  def injector: Injector = js.native
 
   def injector(modules: js.Array[String]): Injector = js.native
 


### PR DESCRIPTION
The current parameterless implementation of `Angular.injector()` indeed isn't working (runtime failure). Angular expects the list of modules to be used by the injector.