### PR TITLE
Helper to embed templates from HTML source files as String.

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/Template.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/Template.scala
@@ -1,5 +1,7 @@
 package com.greencatsoft.angularjs
 
+import scala.language.experimental.macros
+
 trait Templated {
 
   val templateUrl: String
@@ -8,4 +10,36 @@ trait Templated {
 trait TemplateSource {
 
   val template: String
+}
+
+/** Helper to embed templates from HTML source files as `String`.
+  *
+  * For example load a template from a file relative to the current source file: {{{
+  *   val templateUrl = Template.relativeTemplate("./my-template.html")
+  * }}}
+  *
+  * If the following code is placed in `MyDirective.scala` the content of `MyDirective.html` from the same source
+  * directory will be embedded: {{{
+  *   val templateUrl = Template.companionTemplate
+  * }}}
+  */
+object Template {
+  /** Provides the content from the specified source file as `String` constant.
+    *
+    * Fails at compile time, if the specified file does not exist.
+    *
+    * @param relativePath path relative to the source file, this method is called from.
+    * @return the content of the specified file.
+    */
+  def relativeTemplate(relativePath: String): String = macro internal.Template.relativeTemplate
+
+  /** Provides the content from the companion template as `String` constant.
+    * The companion template is a file which is named exactly as the Scala source file, this method is called from,
+    * but with a `.html` extension instead of the `.scala` extension.
+    *
+    * Fails at compile time, if the specified file does not exist.
+    *
+    * @return the content of the companion template file.
+    */
+  def companionTemplate: String = macro internal.Template.companionTemplate
 }

--- a/src/main/scala/com/greencatsoft/angularjs/internal/Template.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/internal/Template.scala
@@ -1,0 +1,46 @@
+package com.greencatsoft.angularjs.internal
+
+import java.io.File
+
+import scala.io.Source
+import scala.reflect.macros.blackbox.Context
+
+/** Macro implementation for [[com.greencatsoft.angularjs.Template]]. */
+private[angularjs] object Template {
+  def relativeTemplate(c: Context)(relativePath: c.Expr[String]): c.Expr[String] = {
+    import c.universe._
+
+    val Literal(Constant(relativePathConstant: String)) = relativePath.tree
+    val relativeTemplateFile = new File(sourceFile(c), relativePathConstant)
+    val content = fileAsString(c)(relativeTemplateFile)
+    c.Expr[String](q"$content")
+  }
+
+  def companionTemplate(c: Context): c.Expr[String] = {
+    import c.universe._
+
+    val companionTemplateFile = {
+      val sourcePath = sourceFile(c).getAbsolutePath
+      val templatePath = if (sourcePath.endsWith(".scala"))
+        sourcePath.dropRight(".scala".length) + ".html"
+      else
+        c.abort(c.enclosingPosition, s"Companion templates are only supported for scala files. Current contest is $sourcePath.")
+      new File(templatePath)
+    }
+    val content = fileAsString(c)(companionTemplateFile)
+    c.Expr[String](q"$content")
+  }
+
+  private def sourceFile(c: Context): File =
+    c.enclosingPosition.source.file.file
+
+  private def fileAsString(c: Context)(file: File): String = {
+    if (!file.exists)
+      c.abort(c.enclosingPosition, s"No template found at ${file.getAbsolutePath}")
+
+    val source = Source.fromFile(file)
+    val content = source.mkString
+    source.close()
+    content
+  }
+}


### PR DESCRIPTION
For example load a template from a file relative to the current source file: 
```scala
 val templateUrl = Template.relativeTemplate("./my-template.html")
```

 If the following code is placed in `MyDirective.scala` the content of `MyDirective.html` from the same source directory will be embedded: 
```scala
 val templateUrl = Template.companionTemplate
```