### PR TITLE
Adding support for arrayKey config parameter

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
@@ -48,10 +48,8 @@ object FileUploadConfig {
 
     config.url = url
     config.file = file
-    
-    arrayKey match {
-      case Some(key) => {config.arrayKey = key}
-    }  
+
+    arrayKey.foreach(config.arrayKey = _)
     
     data.foreach(config.data = _)
 

--- a/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/FileUpload.scala
@@ -34,11 +34,13 @@ trait FileUploadConfig extends js.Object {
   var fileName: js.Any = js.native
 
   var fileFormDataName: js.Any = js.native
+  
+  var arrayKey: String = js.native
 }
 
 object FileUploadConfig {
 
-  def apply(url: String, file: File | js.Array[File], data: Option[Any] = None) = {
+  def apply(url: String, file: File | js.Array[File], data: Option[Any] = None, arrayKey: Option[String] = None) = {
     require(url != null, "Missing argument 'url'.")
     require(file != null, "Missing argument 'file'.")
 
@@ -46,7 +48,11 @@ object FileUploadConfig {
 
     config.url = url
     config.file = file
-
+    
+    arrayKey match {
+      case Some(key) => {config.arrayKey = key}
+    }  
+    
     data.foreach(config.data = _)
 
     config


### PR DESCRIPTION
Hi folks,

i worked around this in my project extending the original trait. Would be nice to have this as a default option. In my case spring mvc was not able to map the multipart files automatically if the the js was using ``file[0]``, ``file[]`` etc. so the ``arrayKey`` had to be overwritten with an empty string.

Maybe there even is a more elegant way to this?

Regards,
Thorben