### PR TITLE
Updated injectables names in Modal

### DIFF
--- a/src/main/scala/com/greencatsoft/angularjs/extensions/Modal.scala
+++ b/src/main/scala/com/greencatsoft/angularjs/extensions/Modal.scala
@@ -11,7 +11,7 @@ import scala.scalajs.js
  * @see http://angular-ui.github.io/bootstrap/#/modal
  */
 @js.native
-@injectable("$modal")
+@injectable("$uibModal")
 trait ModalService extends js.Object {
 
   def open[T](options: ModalOptions): ModalInstance[T] = js.native
@@ -52,7 +52,7 @@ object ModalOptions {
 }
 
 @js.native
-@injectable("$modalInstance")
+@injectable("$uibModalInstance")
 trait ModalInstance[T] extends js.Object {
 
   def close(result: T): Unit = js.native


### PR DESCRIPTION
Micro patch to update Modal's injectables names to those of UI Bootstrap current version (1.3.3). There are still some options absent compared to [docs](http://angular-ui.github.io/bootstrap/#/modal), but they were absent in the old wrapper too; I don't know why, so I decided not to add them.